### PR TITLE
Fix index out of range error when parsing/splitting args.

### DIFF
--- a/config.go
+++ b/config.go
@@ -81,5 +81,5 @@ func parseArg(arg, sep string) (string, string, error) {
 	if len(fields) != 2 {
 		return "", "", errors.New("bad config file")
 	}
-	return fields[0], fields[2], nil
+	return fields[0], fields[1], nil
 }


### PR DESCRIPTION
Tests here: https://gist.github.com/glinton/bbae7541b09051afc743
